### PR TITLE
fix(builder): emit classes exported via standalone `export { X }`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.1.1] - 2026-06-28
+
+### 🐛 Fixed
+
+- **Builder**: A class (or other named declaration) exported via a standalone `export { X }` statement — e.g. `class HttpClient {} ... export { HttpClient }` — was misdetected as an internal name collision, renamed to `X_1`, and then dropped from the generated `.d.ts` as unused. The symbol survived only as a type reference (in factory return types, instances, and the export list) without its class declaration. The collision resolver now recognises declarations exported through a local `export { X }` and exempts them from renaming.
+
+### 🧪 Tests
+
+- Added builder regression tests covering inline `export class`, the standalone `export { X }` pattern, classes consumed only as types elsewhere, and that genuine name collisions are still resolved.
+
+### 📚 Examples
+
+- Added `examples/http-client` — an `HttpClient` abstraction (adapter, interceptors, typed models) built on the platform `fetch` with no external dependencies, doubling as a reproduction case for the fix above.
+
 ## [2.0.0] - 2026-02-26
 
 ### 🚀 Major Rewrite

--- a/examples/http-client/README.md
+++ b/examples/http-client/README.md
@@ -1,0 +1,69 @@
+# HTTP Client Example
+
+This example mirrors a real-world `src/infrastructure/http` module — an
+`HttpClient` abstraction over a pluggable adapter, interceptors, and typed
+request/response/error models. The adapter is implemented on top of the
+platform `fetch` API, so the example pulls in **no external libraries** (no
+axios).
+
+It also serves as a **regression case** for a bug where a class exported via the
+`class X {} ... export { X }` pattern was emitted as a *type reference only* —
+the `class X { ... }` declaration itself was dropped from the generated `.d.ts`.
+
+## Files
+
+- `src/lib/http-client.ts` — the `HttpClient` class (declared, then `export { HttpClient }`)
+- `src/lib/request-abort-controller.ts` — request cancellation helper
+- `src/lib/models/` — `HttpResponse`, `HttpError`, `HttpRequestConfig`, `HttpAdapter`, interceptor models
+- `src/fetch-http-adapter.ts` — `fetch`-based `HttpAdapter` implementation
+- `src/fetch-interceptor-manager.ts` — array-backed interceptor manager
+- `src/http-client-factory.ts` — `HttpClientFactory`
+- `src/http.ts` — ready-to-use `http` instance
+- `src/index.ts` — public barrel (re-exports `HttpClient` and friends)
+- `build.ts` — generates `dist/http-client.d.ts`
+
+## Running the Example
+
+```bash
+# From the project root
+npx ts-node --transpileOnly --compiler-options '{"module":"commonjs","moduleResolution":"node10"}' examples/http-client/build.ts
+```
+
+## Expected Output
+
+The generated `dist/http-client.d.ts` declares a single ambient module that
+contains the **full `class HttpClient` declaration** (not just a reference):
+
+```typescript
+declare module "@infra/http" {
+  class HttpClient {
+    readonly interceptorManager: HttpInterceptorManager;
+    constructor(httpAdapter: HttpAdapter);
+    get<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    // ...the rest of the public surface...
+  }
+  class HttpClientFactory {
+    static create(adapter?: HttpAdapter): HttpClient;
+  }
+  const http: HttpClient;
+  export { HttpClient, HttpClientFactory, http /* ...types... */ };
+}
+```
+
+## Why the `export { X }` pattern matters
+
+When a declaration is exported indirectly:
+
+```typescript
+class HttpClient { /* ... */ }
+export { HttpClient };
+```
+
+the builder must recognise that `HttpClient` is the real exported symbol. Before
+the fix, the collision resolver only looked for an inline `export` modifier on
+the declaration, mistook this class for an internal name colliding with the
+re-exported `HttpClient`, renamed it to `HttpClient_1`, and then dropped it as
+unused — leaving the class referenced only as a type.

--- a/examples/http-client/build.ts
+++ b/examples/http-client/build.ts
@@ -1,0 +1,28 @@
+/**
+ * Build script for generating type declarations for the HTTP client example.
+ *
+ * Mirrors a real-world `src/infrastructure/http` module (HttpClient + adapter +
+ * interceptors) and emits a single ambient `.d.ts` consumable by other apps.
+ */
+import build from '../../packages/builder/build';
+import path from 'path';
+import prettier from 'prettier';
+
+async function main() {
+  await build({
+    entries: [{ name: '@infra/http', filename: path.resolve(__dirname, 'src/index.ts') }],
+    output: {
+      filename: path.resolve(__dirname, 'dist/http-client.d.ts'),
+      format: (result) => prettier.format(result, { parser: 'typescript' }),
+    },
+    tsconfig: path.resolve(__dirname, '../../tsconfig.json'),
+  });
+
+  console.log('✅ Type declarations generated successfully!');
+  console.log('📄 Output: examples/http-client/dist/http-client.d.ts');
+}
+
+main().catch((error) => {
+  console.error('❌ Build failed:', error);
+  process.exit(1);
+});

--- a/examples/http-client/dist/http-client.d.ts
+++ b/examples/http-client/dist/http-client.d.ts
@@ -1,0 +1,200 @@
+﻿declare module "@infra/http" {
+  interface HttpRequestConfig<Data = unknown> {
+    url?: string;
+    method?: string;
+    baseURL?: string;
+    data?: Data;
+    params?: Record<string, unknown>;
+    headers?: Headers;
+    timeout?: number;
+    signal?: AbortSignal;
+    responseType?:
+      | "json"
+      | "text"
+      | "blob"
+      | "arraybuffer"
+      | "document"
+      | "stream"
+      | "formdata";
+    withCredentials?: boolean;
+    maxRedirects?: number;
+    validateStatus?: (status: number) => boolean;
+  }
+  interface HttpInternalRequestConfig<
+    Data = unknown,
+  > extends HttpRequestConfig<Data> {
+    headers: Headers;
+    validateStatus: (status: number) => boolean;
+  }
+  interface HttpResponse<T = unknown, D = unknown> {
+    data: T;
+    status: number;
+    statusText: string;
+    headers: Headers;
+    config: HttpInternalRequestConfig<D>;
+  }
+  class HttpError<T = unknown> extends Error {
+    readonly status?: number | undefined;
+    readonly config?: HttpInternalRequestConfig<T> | undefined;
+    readonly response?: HttpResponse<T> | undefined;
+    constructor(
+      message?: string,
+      status?: number | undefined,
+      config?: HttpInternalRequestConfig<T> | undefined,
+      response?: HttpResponse<T> | undefined,
+    );
+  }
+  interface FulfilledCallback<T> {
+    (value: T): T | Promise<T>;
+  }
+  interface RejectedCallback<E = HttpError> {
+    (error: E): E | Promise<E>;
+  }
+  type UseInterceptorParams<V> = {
+    onFulfilled?: FulfilledCallback<V>;
+    onRejected?: RejectedCallback;
+  };
+  interface UseInterceptor<V> {
+    (cbs: UseInterceptorParams<V>): InterceptorId;
+  }
+  type InterceptorId = number;
+  interface HttpInterceptorManager {
+    registerRequestInterceptor: UseInterceptor<HttpInternalRequestConfig>;
+    registerResponseInterceptor: UseInterceptor<HttpResponse>;
+    unregisterRequestInterceptor(interceptorId: InterceptorId): void;
+    unregisterResponseInterceptor(interceptorId: InterceptorId): void;
+    unregisterAllResponseInterceptor(): void;
+    unregisterAllRequestInterceptor(): void;
+  }
+  interface HttpAdapter {
+    interceptorManager: HttpInterceptorManager;
+    request<T = unknown, R = HttpResponse<T>, D = unknown>(
+      config: HttpRequestConfig<D>,
+    ): Promise<R>;
+    options<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    get<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    getUri(config?: HttpRequestConfig): string;
+    head<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    patch<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    post<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    put<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    delete<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    patchForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    postForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    putForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    isHttpError<T = unknown>(error: unknown): error is HttpError<T>;
+  }
+  class HttpClient {
+    readonly interceptorManager: HttpInterceptorManager;
+    constructor(httpAdapter: HttpAdapter);
+    abortAll(reason?: unknown): void;
+    abortLast(reason?: unknown): void;
+    abortFirst(reason?: unknown): void;
+    abortSelected(numberRequest: number, reason?: unknown): void;
+    request<T = unknown, R = HttpResponse<T>, D = unknown>(
+      config: HttpRequestConfig<D>,
+    ): Promise<R>;
+    options<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    get<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    getUri(config?: HttpRequestConfig): string;
+    head<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    patch<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    post<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    put<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data?: D,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    delete<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      config?: HttpRequestConfig<D>,
+    ): Promise<R>;
+    patchForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    postForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    putForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+      url: string,
+      data: D | undefined,
+      config?: HttpRequestConfig<D> | undefined,
+    ): Promise<R>;
+    isHttpError<T = unknown>(error: unknown): error is HttpError<T>;
+  }
+  class HttpClientFactory {
+    static create(adapter?: HttpAdapter): HttpClient;
+    static createWithBaseURL(baseURL: string): HttpClient;
+  }
+  /**
+   * Ready-to-use HTTP client instance backed by the `fetch` adapter.
+   */
+  const http: HttpClient;
+  export {
+    HttpClient,
+    HttpClientFactory,
+    http,
+    HttpResponse,
+    HttpError,
+    HttpRequestConfig,
+    HttpInternalRequestConfig,
+    HttpAdapter,
+  };
+}

--- a/examples/http-client/src/fetch-http-adapter.ts
+++ b/examples/http-client/src/fetch-http-adapter.ts
@@ -1,0 +1,182 @@
+import {
+  HttpAdapter,
+  HttpError,
+  HttpInternalRequestConfig,
+  HttpRequestConfig,
+  HttpResponse,
+} from './lib/models';
+import { FetchInterceptorManager } from './fetch-interceptor-manager';
+
+const DEFAULT_VALIDATE_STATUS = (status: number): boolean => status >= 200 && status < 300;
+
+/**
+ * HTTP adapter built on top of the platform `fetch` — no axios, no external deps.
+ *
+ * Mirrors the axios-based adapter used in production while keeping the example
+ * self-contained.
+ */
+export class FetchHttpAdapter implements HttpAdapter {
+  public readonly interceptorManager: FetchInterceptorManager;
+
+  constructor(
+    private readonly baseURL: string = '',
+    interceptorManager?: FetchInterceptorManager,
+  ) {
+    this.interceptorManager = interceptorManager ?? new FetchInterceptorManager();
+  }
+
+  getUri(config?: HttpRequestConfig): string {
+    const url = config?.url ?? '';
+    const base = config?.baseURL ?? this.baseURL;
+    return new URL(url, base || undefined).toString();
+  }
+
+  async request<T = unknown, R = HttpResponse<T>, D = unknown>(
+    config: HttpRequestConfig<D>,
+  ): Promise<R> {
+    const internalConfig: HttpInternalRequestConfig<D> = {
+      ...config,
+      headers: config.headers ?? new Headers(),
+      validateStatus: config.validateStatus ?? DEFAULT_VALIDATE_STATUS,
+    };
+
+    const finalConfig = await this.interceptorManager.applyRequest(
+      internalConfig as HttpInternalRequestConfig,
+    );
+
+    const uri = this.getUri(finalConfig);
+
+    const init: RequestInit = {
+      method: finalConfig.method ?? 'GET',
+      headers: finalConfig.headers,
+      signal: finalConfig.signal,
+      credentials: finalConfig.withCredentials ? 'include' : 'same-origin',
+    };
+
+    if (finalConfig.data !== undefined && init.method !== 'GET' && init.method !== 'HEAD') {
+      init.body = JSON.stringify(finalConfig.data);
+    }
+
+    const res = await fetch(uri, init);
+    const data = (await this.parseBody(res, finalConfig.responseType)) as T;
+
+    const response: HttpResponse<T, D> = {
+      data,
+      status: res.status,
+      statusText: res.statusText,
+      headers: res.headers,
+      config: finalConfig as HttpInternalRequestConfig<D>,
+    };
+
+    if (!finalConfig.validateStatus(res.status)) {
+      throw new HttpError<T>(
+        `Request failed with status ${res.status}`,
+        res.status,
+        finalConfig as HttpInternalRequestConfig<T>,
+        response as HttpResponse<T>,
+      );
+    }
+
+    const finalResponse = await this.interceptorManager.applyResponse(response as HttpResponse);
+    return finalResponse as R;
+  }
+
+  options<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, method: 'OPTIONS' });
+  }
+
+  get<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, method: 'GET' });
+  }
+
+  head<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, method: 'HEAD' });
+  }
+
+  patch<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'PATCH' });
+  }
+
+  post<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'POST' });
+  }
+
+  put<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'PUT' });
+  }
+
+  delete<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, method: 'DELETE' });
+  }
+
+  patchForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'PATCH' });
+  }
+
+  postForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'POST' });
+  }
+
+  putForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.request<T, R, D>({ ...config, url, data, method: 'PUT' });
+  }
+
+  isHttpError<T = unknown>(error: unknown): error is HttpError<T> {
+    return error instanceof HttpError;
+  }
+
+  private async parseBody(
+    res: Response,
+    responseType?: HttpRequestConfig['responseType'],
+  ): Promise<unknown> {
+    switch (responseType) {
+      case 'text':
+        return res.text();
+      case 'blob':
+        return res.blob();
+      case 'arraybuffer':
+        return res.arrayBuffer();
+      case 'formdata':
+        return res.formData();
+      case 'json':
+      default:
+        return res.status === 204 ? null : res.json();
+    }
+  }
+}

--- a/examples/http-client/src/fetch-interceptor-manager.ts
+++ b/examples/http-client/src/fetch-interceptor-manager.ts
@@ -1,0 +1,66 @@
+import {
+  HttpInterceptorManager,
+  HttpInternalRequestConfig,
+  HttpResponse,
+  InterceptorId,
+  UseInterceptorParams,
+} from './lib/models';
+
+type Interceptor<V> = UseInterceptorParams<V>;
+
+/**
+ * Minimal interceptor manager backed by plain arrays — no external library.
+ */
+export class FetchInterceptorManager implements HttpInterceptorManager {
+  private requestInterceptors = new Map<InterceptorId, Interceptor<HttpInternalRequestConfig>>();
+  private responseInterceptors = new Map<InterceptorId, Interceptor<HttpResponse>>();
+  private nextId = 1;
+
+  registerRequestInterceptor = (cbs: Interceptor<HttpInternalRequestConfig>): InterceptorId => {
+    const id = this.nextId++;
+    this.requestInterceptors.set(id, cbs);
+    return id;
+  };
+
+  registerResponseInterceptor = (cbs: Interceptor<HttpResponse>): InterceptorId => {
+    const id = this.nextId++;
+    this.responseInterceptors.set(id, cbs);
+    return id;
+  };
+
+  unregisterRequestInterceptor(interceptorId: InterceptorId): void {
+    this.requestInterceptors.delete(interceptorId);
+  }
+
+  unregisterResponseInterceptor(interceptorId: InterceptorId): void {
+    this.responseInterceptors.delete(interceptorId);
+  }
+
+  unregisterAllRequestInterceptor(): void {
+    this.requestInterceptors.clear();
+  }
+
+  unregisterAllResponseInterceptor(): void {
+    this.responseInterceptors.clear();
+  }
+
+  async applyRequest(config: HttpInternalRequestConfig): Promise<HttpInternalRequestConfig> {
+    let result = config;
+    for (const { onFulfilled } of this.requestInterceptors.values()) {
+      if (onFulfilled) {
+        result = (await onFulfilled(result)) as HttpInternalRequestConfig;
+      }
+    }
+    return result;
+  }
+
+  async applyResponse(response: HttpResponse): Promise<HttpResponse> {
+    let result = response;
+    for (const { onFulfilled } of this.responseInterceptors.values()) {
+      if (onFulfilled) {
+        result = (await onFulfilled(result)) as HttpResponse;
+      }
+    }
+    return result;
+  }
+}

--- a/examples/http-client/src/http-client-factory.ts
+++ b/examples/http-client/src/http-client-factory.ts
@@ -1,0 +1,13 @@
+import { HttpClient } from './lib/http-client';
+import { HttpAdapter } from './lib/models';
+import { FetchHttpAdapter } from './fetch-http-adapter';
+
+export class HttpClientFactory {
+  static create(adapter?: HttpAdapter): HttpClient {
+    return new HttpClient(adapter ?? new FetchHttpAdapter());
+  }
+
+  static createWithBaseURL(baseURL: string): HttpClient {
+    return new HttpClient(new FetchHttpAdapter(baseURL));
+  }
+}

--- a/examples/http-client/src/http.ts
+++ b/examples/http-client/src/http.ts
@@ -1,0 +1,6 @@
+import { HttpClientFactory } from './http-client-factory';
+
+/**
+ * Ready-to-use HTTP client instance backed by the `fetch` adapter.
+ */
+export const http = HttpClientFactory.create();

--- a/examples/http-client/src/index.ts
+++ b/examples/http-client/src/index.ts
@@ -1,0 +1,10 @@
+export { HttpClient } from './lib/http-client';
+export { HttpClientFactory } from './http-client-factory';
+export { http } from './http';
+export type {
+  HttpResponse,
+  HttpError,
+  HttpRequestConfig,
+  HttpInternalRequestConfig,
+  HttpAdapter,
+} from './lib/models';

--- a/examples/http-client/src/lib/http-client.ts
+++ b/examples/http-client/src/lib/http-client.ts
@@ -1,0 +1,133 @@
+import {
+  HttpAdapter,
+  HttpRequestConfig,
+  HttpResponse,
+  HttpError,
+  HttpInterceptorManager,
+} from './models';
+import { RequestAbortController } from './request-abort-controller';
+
+class HttpClient {
+  private readonly abortController = new RequestAbortController();
+  public readonly interceptorManager: HttpInterceptorManager;
+
+  constructor(private readonly httpAdapter: HttpAdapter) {
+    this.interceptorManager = this.httpAdapter.interceptorManager;
+    this.setupAbortController();
+  }
+
+  private setupAbortController(): void {
+    this.httpAdapter.interceptorManager.registerRequestInterceptor({
+      onFulfilled: (config) => {
+        config.signal = this.abortController.createSignal();
+        return config;
+      },
+    });
+  }
+
+  abortAll(reason?: unknown): void {
+    this.abortController.abortAll(reason);
+  }
+
+  abortLast(reason?: unknown): void {
+    this.abortController.abortLast(reason);
+  }
+
+  abortFirst(reason?: unknown): void {
+    this.abortController.abortFirst(reason);
+  }
+
+  abortSelected(numberRequest: number, reason?: unknown): void {
+    this.abortController.abortSelected(numberRequest, reason);
+  }
+
+  request<T = unknown, R = HttpResponse<T>, D = unknown>(config: HttpRequestConfig<D>): Promise<R> {
+    return this.httpAdapter.request(config);
+  }
+
+  options<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.options(url, config);
+  }
+
+  get<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.get(url, config);
+  }
+
+  getUri(config?: HttpRequestConfig): string {
+    return this.httpAdapter.getUri(config);
+  }
+
+  head<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.head(url, config);
+  }
+
+  patch<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.patch(url, data, config);
+  }
+
+  post<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.post(url, data, config);
+  }
+
+  put<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.put(url, data, config);
+  }
+
+  delete<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R> {
+    return this.httpAdapter.delete(url, config);
+  }
+
+  patchForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.httpAdapter.patchForm(url, data, config);
+  }
+
+  postForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.httpAdapter.postForm(url, data, config);
+  }
+
+  putForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R> {
+    return this.httpAdapter.putForm(url, data, config);
+  }
+
+  isHttpError<T = unknown>(error: unknown): error is HttpError<T> {
+    return this.httpAdapter.isHttpError(error);
+  }
+}
+
+export { HttpClient };

--- a/examples/http-client/src/lib/models/http-adapter.model.ts
+++ b/examples/http-client/src/lib/models/http-adapter.model.ts
@@ -1,0 +1,57 @@
+import { HttpError } from './http-error.model';
+import { HttpRequestConfig } from './http-request-config.model';
+import { HttpResponse } from './http-response.model';
+import type { HttpInterceptorManager } from './http-interceptor-manager.model';
+
+export interface HttpAdapter {
+  interceptorManager: HttpInterceptorManager;
+  request<T = unknown, R = HttpResponse<T>, D = unknown>(config: HttpRequestConfig<D>): Promise<R>;
+  options<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  get<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  getUri(config?: HttpRequestConfig): string;
+  head<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  patch<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  post<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  put<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data?: D,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  delete<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    config?: HttpRequestConfig<D>,
+  ): Promise<R>;
+  patchForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R>;
+  postForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R>;
+  putForm<T = unknown, R = HttpResponse<T>, D = unknown>(
+    url: string,
+    data: D | undefined,
+    config?: HttpRequestConfig<D> | undefined,
+  ): Promise<R>;
+  isHttpError<T = unknown>(error: unknown): error is HttpError<T>;
+}

--- a/examples/http-client/src/lib/models/http-error.model.ts
+++ b/examples/http-client/src/lib/models/http-error.model.ts
@@ -1,0 +1,14 @@
+import { HttpInternalRequestConfig } from './http-request-config.model';
+import { HttpResponse } from './http-response.model';
+
+export class HttpError<T = unknown> extends Error {
+  constructor(
+    message?: string,
+    public readonly status?: number,
+    public readonly config?: HttpInternalRequestConfig<T>,
+    public readonly response?: HttpResponse<T>,
+  ) {
+    super(message);
+    this.name = 'HttpError';
+  }
+}

--- a/examples/http-client/src/lib/models/http-interceptor-manager.model.ts
+++ b/examples/http-client/src/lib/models/http-interceptor-manager.model.ts
@@ -1,0 +1,31 @@
+import { HttpError } from './http-error.model';
+import { HttpInternalRequestConfig } from './http-request-config.model';
+import { HttpResponse } from './http-response.model';
+
+export interface FulfilledCallback<T> {
+  (value: T): T | Promise<T>;
+}
+
+export interface RejectedCallback<E = HttpError> {
+  (error: E): E | Promise<E>;
+}
+
+export type UseInterceptorParams<V> = {
+  onFulfilled?: FulfilledCallback<V>;
+  onRejected?: RejectedCallback;
+};
+
+export interface UseInterceptor<V> {
+  (cbs: UseInterceptorParams<V>): InterceptorId;
+}
+
+export type InterceptorId = number;
+
+export interface HttpInterceptorManager {
+  registerRequestInterceptor: UseInterceptor<HttpInternalRequestConfig>;
+  registerResponseInterceptor: UseInterceptor<HttpResponse>;
+  unregisterRequestInterceptor(interceptorId: InterceptorId): void;
+  unregisterResponseInterceptor(interceptorId: InterceptorId): void;
+  unregisterAllResponseInterceptor(): void;
+  unregisterAllRequestInterceptor(): void;
+}

--- a/examples/http-client/src/lib/models/http-request-config.model.ts
+++ b/examples/http-client/src/lib/models/http-request-config.model.ts
@@ -1,0 +1,19 @@
+export interface HttpRequestConfig<Data = unknown> {
+  url?: string;
+  method?: string;
+  baseURL?: string;
+  data?: Data;
+  params?: Record<string, unknown>;
+  headers?: Headers;
+  timeout?: number;
+  signal?: AbortSignal;
+  responseType?: 'json' | 'text' | 'blob' | 'arraybuffer' | 'document' | 'stream' | 'formdata';
+  withCredentials?: boolean;
+  maxRedirects?: number;
+  validateStatus?: (status: number) => boolean;
+}
+
+export interface HttpInternalRequestConfig<Data = unknown> extends HttpRequestConfig<Data> {
+  headers: Headers;
+  validateStatus: (status: number) => boolean;
+}

--- a/examples/http-client/src/lib/models/http-response.model.ts
+++ b/examples/http-client/src/lib/models/http-response.model.ts
@@ -1,0 +1,9 @@
+import { HttpInternalRequestConfig } from './http-request-config.model';
+
+export interface HttpResponse<T = unknown, D = unknown> {
+  data: T;
+  status: number;
+  statusText: string;
+  headers: Headers;
+  config: HttpInternalRequestConfig<D>;
+}

--- a/examples/http-client/src/lib/models/index.ts
+++ b/examples/http-client/src/lib/models/index.ts
@@ -1,0 +1,12 @@
+export type {
+  HttpInterceptorManager,
+  InterceptorId,
+  UseInterceptor,
+  FulfilledCallback,
+  RejectedCallback,
+  UseInterceptorParams,
+} from './http-interceptor-manager.model';
+export type { HttpAdapter } from './http-adapter.model';
+export type { HttpRequestConfig, HttpInternalRequestConfig } from './http-request-config.model';
+export type { HttpResponse } from './http-response.model';
+export { HttpError } from './http-error.model';

--- a/examples/http-client/src/lib/request-abort-controller.ts
+++ b/examples/http-client/src/lib/request-abort-controller.ts
@@ -1,0 +1,37 @@
+export class RequestAbortController {
+  private controllers: AbortController[] = [];
+
+  createSignal(): AbortSignal {
+    const controller = new AbortController();
+    this.controllers.push(controller);
+    return controller.signal;
+  }
+
+  abortAll(reason?: unknown): void {
+    this.controllers.forEach((controller) => {
+      controller.abort(reason);
+    });
+    this.controllers = [];
+  }
+
+  abortLast(reason?: unknown): void {
+    const last = this.controllers.pop();
+    if (last) {
+      last.abort(reason);
+    }
+  }
+
+  abortFirst(reason?: unknown): void {
+    const first = this.controllers.shift();
+    if (first) {
+      first.abort(reason);
+    }
+  }
+
+  abortSelected(numberRequest: number, reason?: unknown): void {
+    const [selected] = this.controllers.splice(numberRequest - 1, 1);
+    if (selected) {
+      selected.abort(reason);
+    }
+  }
+}

--- a/packages/builder/__test__/build.test.ts
+++ b/packages/builder/__test__/build.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, beforeEach, afterEach } from 'node:test';
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import build from '../build';
+
+let tmpDir: string;
+
+function writeFiles(files: Record<string, string>): string {
+  const srcDir = path.join(tmpDir, 'src');
+  for (const [name, content] of Object.entries(files)) {
+    const filePath = path.join(srcDir, name);
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, content);
+  }
+  return srcDir;
+}
+
+async function buildModule(srcDir: string, moduleName = 'test'): Promise<string> {
+  const outputPath = path.join(tmpDir, 'dist', 'types.d.ts');
+  await build({
+    entries: [{ name: moduleName, filename: path.join(srcDir, 'index.ts') }],
+    output: { filename: outputPath },
+    tsconfig: path.resolve(process.cwd(), 'tsconfig.json'),
+  });
+  return fs.readFileSync(outputPath, 'utf-8');
+}
+
+describe('builder: declaration emit', () => {
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'ts-remote-build-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('emits a class exported inline via `export class`', async () => {
+    const srcDir = writeFiles({
+      'foo.ts': `export class Foo { bar(): number { return 1; } }`,
+      'index.ts': `export { Foo } from './foo';`,
+    });
+
+    const dts = await buildModule(srcDir);
+
+    assert.match(dts, /class Foo\b/, 'class Foo declaration should be present');
+    assert.match(dts, /bar\(\): number;/, 'class members should be present');
+  });
+
+  it('emits a class exported via a standalone `export { X }` statement', async () => {
+    // Regression: the `class X {} ... export { X }` pattern was misdetected as
+    // an internal name collision, renamed to `X_1`, and dropped from the output —
+    // leaving the class referenced only as a type.
+    const srcDir = writeFiles({
+      'foo.ts': `class Foo { bar(): number { return 1; } }\nexport { Foo };`,
+      'index.ts': `export { Foo } from './foo';`,
+    });
+
+    const dts = await buildModule(srcDir);
+
+    assert.match(dts, /class Foo\b/, 'class Foo declaration must be emitted, not just referenced');
+    assert.match(dts, /bar\(\): number;/, 'class members should be present');
+    assert.doesNotMatch(dts, /Foo_1/, 'class must not be renamed as a false collision');
+    assert.match(dts, /export \{[^}]*\bFoo\b/, 'Foo should be exported');
+  });
+
+  it('emits a class consumed only as a type elsewhere when exported via `export { X }`', async () => {
+    // Reproduces the original report: a factory/instance references HttpClient as
+    // a type while the class itself is exported through `export { HttpClient }`.
+    const srcDir = writeFiles({
+      'client.ts': `class Client { ping(): void {} }\nexport { Client };`,
+      'factory.ts': `import { Client } from './client';\nexport class Factory { static create(): Client { return new Client(); } }`,
+      'index.ts': `export { Client } from './client';\nexport { Factory } from './factory';`,
+    });
+
+    const dts = await buildModule(srcDir);
+
+    assert.match(dts, /class Client\b/, 'class Client must be emitted as a declaration');
+    assert.match(dts, /class Factory\b/, 'class Factory must be emitted');
+    assert.match(dts, /static create\(\): Client;/, 'Factory should reference Client as a type');
+    assert.doesNotMatch(dts, /Client_1/, 'Client must not be renamed');
+  });
+
+  it('still resolves genuine name collisions between exported and internal symbols', async () => {
+    // The exported `Status` and the unrelated internal `Status` in helper.ts must
+    // remain distinct: the internal one is renamed, the exported one is not.
+    const srcDir = writeFiles({
+      'helper.ts': `type Status = 'internal';\nexport function describe(s: Status): string { return s; }`,
+      'index.ts': `export type Status = 'a' | 'b';\nexport { describe } from './helper';`,
+    });
+
+    const dts = await buildModule(srcDir);
+
+    assert.match(
+      dts,
+      /type Status = ['"]a['"] \| ['"]b['"]/,
+      'exported Status should keep its name',
+    );
+    assert.match(dts, /Status_1/, 'internal colliding Status should be renamed');
+  });
+});

--- a/packages/builder/emitter.ts
+++ b/packages/builder/emitter.ts
@@ -235,6 +235,36 @@ export class Emitter {
     ts.forEachChild(sourceFile, visit);
   }
 
+  /**
+   * Collect names exported from a file via a standalone `export { ... }`
+   * declaration that has no module specifier (i.e. re-exporting local
+   * declarations, not `export { x } from "..."`).
+   *
+   * These names belong to declarations defined in the same file using the
+   * `class X {} ... export { X }` pattern, and must be exempt from the internal
+   * name-collision renaming.
+   */
+  private collectLocalExportNames(sourceFile: ts.SourceFile): Set<string> {
+    const names = new Set<string>();
+
+    for (const statement of sourceFile.statements) {
+      if (
+        ts.isExportDeclaration(statement) &&
+        !statement.moduleSpecifier &&
+        statement.exportClause &&
+        ts.isNamedExports(statement.exportClause)
+      ) {
+        for (const element of statement.exportClause.elements) {
+          // Use the local name (propertyName when aliased: `export { Local as Public }`)
+          const localName = element.propertyName?.text ?? element.name.text;
+          names.add(localName);
+        }
+      }
+    }
+
+    return names;
+  }
+
   private transformFile(
     sourceFile: ts.SourceFile,
     context: ts.TransformationContext,
@@ -242,6 +272,12 @@ export class Emitter {
     const statementVisitor = this.getStatementVisitor(context);
 
     const isRootFile = sourceFile.fileName === this.#rootFile.fileName;
+
+    // Names exported from this file via a standalone `export { X }` declaration
+    // (no module specifier). Such declarations are the symbol's real export, so
+    // the corresponding `class X {}` / `interface X {}` must NOT be treated as an
+    // internal name collision and renamed.
+    const locallyExportedNames = this.collectLocalExportNames(sourceFile);
 
     const exportsSpecifiers: ts.ExportSpecifier[] = [];
     const seenSpecifiers = new Set<string>();
@@ -589,10 +625,12 @@ export class Emitter {
           : rootNode.name?.text;
 
         if (nodeName && this.isExportedName(nodeName)) {
-          // Check if it's exported from this file
+          // Check if it's exported from this file — either inline
+          // (`export class X`) or via a standalone `export { X }` declaration.
           const isExportedFromThisFile =
-            ts.canHaveModifiers(rootNode) &&
-            rootNode.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword);
+            (ts.canHaveModifiers(rootNode) &&
+              rootNode.modifiers?.some((m) => m.kind === ts.SyntaxKind.ExportKeyword)) ||
+            locallyExportedNames.has(nodeName);
 
           if (!isExportedFromThisFile) {
             // This is an internal declaration that collides with an exported name


### PR DESCRIPTION
A class declared then exported through a separate `export { X }` statement (e.g. `class HttpClient {} ... export { HttpClient }`) was misdetected as an internal name collision with the re-exported symbol, renamed to `X_1`, and then dropped from the generated `.d.ts` as unused — leaving the symbol referenced only as a type, with no class declaration.

The collision resolver now collects names exported via a local `export { X }` (no module specifier) and exempts them from renaming. Genuine collisions between unrelated same-named symbols are still resolved.

Adds builder regression tests and an `examples/http-client` reproduction case (fetch-based HttpClient abstraction, no external dependencies).